### PR TITLE
Adjusted for Labour and FS-N sectors

### DIFF
--- a/definitions/geo_dataset.json
+++ b/definitions/geo_dataset.json
@@ -25,7 +25,6 @@
       "fire",
       "forestry",
       "health",
-      "labour",
       "lakes_global",
       "lakes_local",
       "peat",
@@ -60,7 +59,6 @@
       "fire",
       "forestry",
       "health",
-      "labour",
       "lakes_global",
       "lakes_local",
       "peat",
@@ -95,7 +93,6 @@
       "fire",
       "forestry",
       "health",
-      "labour",
       "lakes_global",
       "lakes_local",
       "peat",
@@ -130,6 +127,7 @@
       "fire",
       "forestry",
       "health",
+      "fs-n",
       "labour",
       "lakes_global",
       "lakes_local",
@@ -165,6 +163,7 @@
       "fire",
       "forestry",
       "health",
+      "fs-n",
       "labour",
       "lakes_global",
       "lakes_local",
@@ -172,6 +171,27 @@
       "permafrost",
       "water_global",
       "water_regional"
+    ]
+  },
+  {
+    "specifier": "gadm",
+    "group": "countrymasks",
+    "path": {
+      "ISIMIP3a": "ISIMIP3a/InputData/geo_conditions/countrymasks/gadm.gpkg",
+      "ISIMIP3b": "ISIMIP3b/InputData/geo_conditions/countrymasks/gadm.gpkg"
+    },
+    "variables": [
+      {
+        "long_name": "Global Administrative Areas",
+        "specifier": "m_<country-code>",
+        "unit": ""
+      }
+    ],
+    "resolution": "0.5° grid",
+    "format": "binary",
+    "comment": "Database of Global Administrative Areas (GADM) at administrative levels 0,1 and 2 (Version 4.1, 16 July 2022). More formats are available at <https://gadm.org/data.html>.",
+    "sectors": [
+      "fs-n"
     ]
   },
   {
@@ -315,7 +335,6 @@
       "fire",
       "forestry",
       "health",
-      "labour",
       "lakes_global",
       "lakes_local",
       "peat",
@@ -430,7 +449,6 @@
       "fire",
       "forestry",
       "health",
-      "labour",
       "lakes_global",
       "lakes_local",
       "peat",
@@ -464,7 +482,6 @@
       "energy",
       "fire",
       "health",
-      "labour",
       "lakes_global",
       "lakes_local",
       "peat",
@@ -498,7 +515,6 @@
       "energy",
       "fire",
       "health",
-      "labour",
       "lakes_global",
       "lakes_local",
       "peat",
@@ -532,7 +548,6 @@
       "energy",
       "fire",
       "health",
-      "labour",
       "lakes_global",
       "lakes_local",
       "peat",


### PR DESCRIPTION
The GADM dataset is a temporary description, as it's currently in gpkg format and it also has to be compatible with the other ISIMIP country masks. Currently waiting for support from the GADM team in terms of data conversion.