### PR TITLE
Included variables for Labour and FS-N

### DIFF
--- a/definitions/variable.json
+++ b/definitions/variable.json
@@ -5782,5 +5782,117 @@
     ],
     "specifier": "socage",
     "units": "yr"
+  },
+  {
+    "comment": "Labour supply measured in percentage-point change (pp). Should be reported separately for each exposure type (see note below the table).",
+    "extension": [
+      null,
+      "<exp>"
+    ],
+    "frequency": "annual",
+    "group": "labour-variables",
+    "long_name": "Labour supply",
+    "resolution": "0.5° grid",
+    "sectors": [
+      "peat"
+    ],
+    "specifier": "labsupp",
+    "units": "pp"
+  },
+  {
+    "comment": "Labour productivity measured in percentage-point change (pp). Should be reported separately for each exposure type (see note below the table).",
+    "extension": [
+      null,
+      "<exp>"
+    ],
+    "frequency": "annual",
+    "group": "labour-variables",
+    "long_name": "Labour productivity",
+    "resolution": "0.5° grid",
+    "sectors": [
+      "peat"
+    ],
+    "specifier": "labprod",
+    "units": "pp"
+  },
+  {
+    "comment": "Effective labour measured in percentage-point change (pp). Should be reported separately for each exposure type (see note below the table).",
+    "extension": [
+      null,
+      "<exp>"
+    ],
+    "frequency": "annual",
+    "group": "labour-variables",
+    "long_name": "Effective labour",
+    "resolution": "0.5° grid",
+    "sectors": [
+      "peat"
+    ],
+    "specifier": "labeff",
+    "units": "pp"
+  },
+  {
+    "comment": "Fraction of the population in grid cell affected.",
+    "extension": [
+      null,
+      "<exp>"
+    ],
+    "frequency": "annual",
+    "group": "fs-n-variables",
+    "long_name": "Fraction of population affected by moderate to severe food insecurity ",
+    "resolution": "0.5° grid",
+    "sectors": [
+      "peat"
+    ],
+    "specifier": "modesevfipc",
+    "units": "%"
+  },
+  {
+    "comment": "Fraction of the population in grid cell affected.",
+    "extension": [
+      null,
+      "<exp>"
+    ],
+    "frequency": "annual",
+    "group": "fs-n-variables",
+    "long_name": "Fraction of population affected by severe food insecurity ",
+    "resolution": "0.5° grid",
+    "sectors": [
+      "peat"
+    ],
+    "specifier": "sevfipc",
+    "units": "%"
+  },
+  {
+    "comment": "Number of people in grid cell affected.",
+    "extension": [
+      null,
+      "<exp>"
+    ],
+    "frequency": "annual",
+    "group": "fs-n-variables",
+    "long_name": "Number of people affected by moderate to severe food insecurity",
+    "resolution": "0.5° grid",
+    "sectors": [
+      "peat"
+    ],
+    "specifier": "modesevfipop",
+    "units": "1"
+  },
+  {
+    "comment": "Number of people in grid cell affected.",
+    "extension": [
+      null,
+      "<exp>"
+    ],
+    "frequency": "annual",
+    "group": "fs-n-variables",
+    "long_name": "Number of people affected by severe food insecurity",
+    "resolution": "0.5° grid",
+    "sectors": [
+      "peat"
+    ],
+    "specifier": "sevfipop",
+    "units": "1"
   }
 ]


### PR DESCRIPTION
We might need to add specifiers depending on how we handle attribution runs, but this is the version assuming that such specifier will be included at the model-name level.