### PR TITLE
add notes about PFT variable attributes

### DIFF
--- a/protocol/04.output.md
+++ b/protocol/04.output.md
@@ -82,6 +82,7 @@ Many variables are defined per area (unit m-2). Typically, and unless otherwise 
     * The output provided per Plant Functional Type (PFT) should be expressed relative to the respective PFT area so that e.g. sum(gpp-pft\*pft-pft)=gpp-total.
     * When your model allows several PFTs to grow on the same area and hence the total cover fraction can be more than one, please scale the PFT area to one and report this step in the model documentation on the ISIMIP homepage.
     * When your model grows the same PFT on different land-use classes, e.g. the same c3-grass represents grasses growing on natural grasslands, pasture and possible even as crop, please differentiate this in your output by defining land-use specific PFT such as c3-grass-pasture, c3-grass-natural, c3-grass-crop and report this in model documentation on the ISIMIP homepage.
+    * For better understanding the abbreviations in the filename please provide the full PFT name in a `pft` variable attribute.
 
 ::: show sector=peat,permafrost
 

--- a/protocol/05.reporting.md
+++ b/protocol/05.reporting.md
@@ -23,6 +23,7 @@ File names consist of a series of identifier, separated by underscores. Things t
 * `!!!`**[modified 2022-12-08]** Use the `standard`, `proleptic_gregorian`, or `365_day` calendar depending on the temporal resolution of your model for **all** types of reported temporal resolutions and write data based on a **daily time index** (`days since ...`). Avoid using the `360_day` calendar for monthly and annual data.
 * For fixed variables (e.g. cellarea, contfrac) omit the NetCDF-internal times dimension but add the period identifiers `0000_0000` in the file name.
 * Set NetCDF internal chunking to use one chunk per record, i.e., one horizontal field, level, and one time step.
+* The variable attributes `axis`, `standard_name`, `long_name`, `calendar`, `missing_value`, `units`, `comment`, `enteric_infection`, `description`, `unit_conversion_info`, `positive`, `bounds`, `classes`, `pft` and  `fuelclass` are whitelisted in the QC-Tool and will not be deleted during formal file checks. Keep in mind to put additional infomations only into these attributes.
 
 Please name the files according to a sector specific pattern:
 


### PR DESCRIPTION
We decided on `pft` variable attributes to have the PFT long lames shipped with the files but never integrated nor announced the change in the protocol