### PR TITLE
Harmonize 'Reservoirs and dams' titles and reduce sector dependecies

### DIFF
--- a/definitions/forcing_data/histsoc.yaml
+++ b/definitions/forcing_data/histsoc.yaml
@@ -217,7 +217,7 @@
 
 - specifier: histsoc_reservoirs_dams
   group: histsoc-forcing
-  title: Dams and reservoirs
+  title: Reservoirs and dams
   status: optional
   doi:
     ISIMIP3a: https://doi.org/10.48364/ISIMIP.769035
@@ -227,25 +227,16 @@
     ISIMIP3b: ISIMIP3b/InputData/socioeconomic/reservoirs_dams/histsoc/
   comment:
     ISIMIP3a: >-
-      Input dataset documentation → [Dams & reservoirs](https://www.isimip.org/gettingstarted/input-data-bias-adjustment/details/129).
+      Input dataset documentation → [Reservoirs and dams](https://www.isimip.org/gettingstarted/input-data-bias-adjustment/details/129).
     ISIMIP3b: >-
-      Input dataset documentation → [Reservoirs & dams ](https://www.isimip.org/gettingstarted/input-data-bias-adjustment/details/130).
+      Input dataset documentation → [Reservoirs and dams ](https://www.isimip.org/gettingstarted/input-data-bias-adjustment/details/130).
   sectors:
   - agriculture
-  - biodiversity
   - biomes
-  - diarrhea
   - fire
-  - groundwater
-  - health
-  - labour
-  - lakes_global
-  - lakes_local
   - peat
   - permafrost
   - water_global
-  - water_regional
-  - water_quality
 
 - specifier: histsoc_water_abstraction
   group: histsoc-forcing
@@ -261,20 +252,11 @@
     Input dataset documentation → [Water abstraction for domestic and industrial uses](https://www.isimip.org/gettingstarted/input-data-bias-adjustment/details/38/).
   sectors:
   - agriculture
-  - biodiversity
   - biomes
-  - diarrhea
   - fire
-  - groundwater
-  - health
-  - labour
-  - lakes_global
-  - lakes_local
   - peat
   - permafrost
   - water_global
-  - water_regional
-  - water_quality
 
 - specifier: histsoc_pctlake
   group: histsoc-forcing

--- a/definitions/forcing_data/sspsoc.yaml
+++ b/definitions/forcing_data/sspsoc.yaml
@@ -626,7 +626,7 @@
 
 - specifier: sspsoc_reservoirs_dams
   group: sspsoc-forcing
-  title: Reservoirs & dams
+  title: Reservoirs and dams
   mandatory: true
   path:
   - ISIMIP3b/InputData/socioeconomic/reservoirs_dams/ssp126soc-adapt/
@@ -636,24 +636,16 @@
   - ISIMIP3b/InputData/socioeconomic/reservoirs_dams/ssp585soc-adapt/
   - ISIMIP3b/InputData/socioeconomic/reservoirs_dams/ssp585soc-noadapt/
   comment: >-
-    Input dataset documentation → [Reservoirs & dams (Group III)](https://www.isimip.org/gettingstarted/input-data-bias-adjustment/details/130/).
+    Input dataset documentation → [Reservoirs and dams (Group III)](https://www.isimip.org/gettingstarted/input-data-bias-adjustment/details/130/).
   simulation_rounds:
   - ISIMIP3b
   sectors:
   - agriculture
-  - biodiversity
   - biomes
-  - diarrhea
-  - groundwater
-  - health
-  - labour
-  - lakes_global
-  - lakes_local
+  - fire
   - peat
   - permafrost
   - water_global
-  - water_regional
-  - water_quality
   group3: true
   noadapt:
   - ssp126
@@ -681,19 +673,11 @@
   - ISIMIP3b
   sectors:
   - agriculture
-  - biodiversity
   - biomes
-  - diarrhea
-  - groundwater
-  - health
-  - labour
-  - lakes_global
-  - lakes_local
+  - fire
   - peat
   - permafrost
   - water_global
-  - water_regional
-  - water_quality
   group3: true
   noadapt:
   - ssp126

--- a/definitions/group.yaml
+++ b/definitions/group.yaml
@@ -139,7 +139,7 @@
   identifier: soc_dataset
 
 - specifier: reservoirs-dams
-  title: Dams and reservoirs
+  title: Reservoirs and dams
   mandatory: false
   identifier: soc_dataset
 

--- a/definitions/group3_requirements.yaml
+++ b/definitions/group3_requirements.yaml
@@ -214,7 +214,7 @@
   - Marine fishing effort
 
 - specifier: reservoirs-dams
-  title: "Water management: Hydropower dams and reservoirs"
+  title: "Water management: Hydropower reservoirs and dams"
   required: []
   harmonized:
   - water_global

--- a/definitions/soc_dataset.yaml
+++ b/definitions/soc_dataset.yaml
@@ -751,7 +751,7 @@
   time_periods: []
 
 - specifier: reservoirs-dams
-  title: Reservoirs & dams
+  title: Reservoirs and dams
   group: reservoirs-dams
   frequency: annual
   resolution: 0.5° grid and original coordinates (degree)
@@ -829,19 +829,11 @@
     contact <info@isimip.org> in case of questions.
   sectors:
   - agriculture
-  - biodiversity
   - biomes
-  - diarrhea
   - fire
-  - groundwater
-  - health
-  - lakes_global
-  - lakes_local
   - peat
   - permafrost
   - water_global
-  - water_regional
-  - water_quality
   time_periods:
     ISIMIP3a:
     - 1850-2020
@@ -849,7 +841,7 @@
     - 1850-2015
 
 - specifier: reservoirs-dams-group-3
-  title: Reservoirs & dams (Group III)
+  title: Reservoirs and dams (Group III)
   group: reservoirs-dams
   frequency: annual
   resolution: original coordinates (degree)
@@ -970,19 +962,11 @@
     Input dataset documentation → [Water abstraction for domestic and industrial uses](https://www.isimip.org/gettingstarted/input-data-bias-adjustment/details/38/), [Water abstraction (group III)](https://www.isimip.org/gettingstarted/input-data-bias-adjustment/details/189/).
   sectors:
   - agriculture
-  - biodiversity
   - biomes
-  - diarrhea
   - fire
-  - groundwater
-  - health
-  - lakes_global
-  - lakes_local
   - peat
   - permafrost
   - water_global
-  - water_regional
-  - water_quality
   time_periods:
     ISIMIP3a:
     - 1601-1849

--- a/definitions/subcategory.yaml
+++ b/definitions/subcategory.yaml
@@ -74,7 +74,7 @@
   - socioeconomic
 
 - specifier: reservoirs_dams
-  title: Dams and reservoirs
+  title: Reservoirs and dams
   categories:
   - socioeconomic
 


### PR DESCRIPTION
As discussed in the 2025-06-18 meeting, reduce dependencies of `Reservoirs and dams` and `Non-irrigation water use` data sets to the same sector list as `Seawater Desalination` and `Inter Basin Water Transfer`